### PR TITLE
Use $window instead of global window

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -7,14 +7,14 @@
 // 'starter.controllers' is found in controllers.js
 angular.module('starter', ['ionic', 'starter.controllers', 'starter.services'])
 
-.run(function($ionicPlatform) {
+.run(function($ionicPlatform, $window) {
   $ionicPlatform.ready(function() {
     // Hide the accessory bar by default (remove this to show the accessory bar above the keyboard
     // for form inputs)
-    if(window.cordova && window.cordova.plugins.Keyboard) {
+    if($window.cordova && $window.cordova.plugins.Keyboard) {
       cordova.plugins.Keyboard.hideKeyboardAccessoryBar(true);
     }
-    if(window.StatusBar) {
+    if($window.StatusBar) {
       // org.apache.cordova.statusbar required
       StatusBar.styleDefault();
     }


### PR DESCRIPTION
While window is globally available in JavaScript, it causes testability problems, because it is a global variable. Using the $window service it may be overridden, removed or mocked for testing.